### PR TITLE
Cancel timeout timer when request has been completed

### DIFF
--- a/lib/ione/rpc/client_peer.rb
+++ b/lib/ione/rpc/client_peer.rb
@@ -88,7 +88,7 @@ module Ione
         end
         if promise && !promise.future.completed?
           promise.fulfill(response)
-          @scheduler.cancel_timer(promise.timeout_future)
+          @scheduler.cancel_timer(promise.timeout_future) if promise.timeout_future
         end
         flush_queue
       end

--- a/spec/ione/rpc/client_peer_spec.rb
+++ b/spec/ione/rpc/client_peer_spec.rb
@@ -149,6 +149,13 @@ module Ione
           expect { f.value }.to_not raise_error
         end
 
+        it 'cancel the timeout timer when the response is received before the timeout passes' do
+          f = peer.send_message('foo', 2)
+          connection.data_listener.call('bar@000')
+          scheduler.timer_promises.first.fulfill
+          scheduler.should have_received(:cancel_timer).once
+        end
+
         it 'fails the request when the connection is closed' do
           connection.stub(:closed?).and_return(true)
           f = peer.send_message('foo', 2)

--- a/spec/ione/rpc/client_peer_spec.rb
+++ b/spec/ione/rpc/client_peer_spec.rb
@@ -53,6 +53,9 @@ module Ione
           timer_promises << Promise.new
           timer_promises.last.future
         end
+        scheduler.stub(:cancel_timer) do |timer|
+          timer_promises.delete(timer)
+        end
         scheduler.stub(:timer_promises).and_return(timer_promises)
       end
 


### PR DESCRIPTION
In the current implementation is each request with a timeout scheduling a timer. This timer will be triggered after a given amount of time to check if the request has been completed or not. If it has not been completed it fails the request with a TimeoutError.

This PR suggest that when a request is handled, the timeout’s timer of the request is canceled. Cancelling its timer prevents the scheduler to spend time dealing with it. It also removes the call, performed for each request, to see if the request has been completed when its timer times out. In case a timeout actually occur, the timeout’s future #on_value will be triggered and simply fail the request.

##### Benchmark

A benchmark performed using a simple client - server setup, sending 20.000 requests.

timeout (s) |  cancel-timeouts (ruby-2.1.1) | master (ruby-2.1.1) | cancel-timeouts (jruby-1.7.16.1) |  master (jruby-1.7.16.1)
-------- | ------------- | ------------- | -----| ------|
nil |   4.020000   1.970000   5.990000 (  5.470043) |   3.960000   1.980000   5.940000 (  5.420814) |  13.700000   3.850000  17.550000 ( 11.085000)  |  14.030000   3.830000  17.860000 ( 11.214000)
1 |      4.130000   1.860000   5.990000 (  5.415695) |  35.560000   2.800000  38.360000 ( 37.739382)      |    13.610000   3.580000  17.190000 ( 10.258000) |  14.940000   3.740000  18.680000 ( 10.985000)
10 | 4.220000   1.780000   6.000000 (  5.414380)      | 111.920000   3.800000 115.720000 (115.084632)      |    14.700000   3.800000  18.500000 ( 10.920000) |  14.490000   3.840000  18.330000 ( 10.682000)
30 |   4.560000   1.890000   6.450000 (  5.872910)     | 184.950000   5.210000 190.160000 (189.704804) | 14.550000   3.770000  18.320000 ( 10.778000) |  14.620000   3.930000  18.550000 ( 10.903000)

As one can see from the result above was there was latency improvement when cancelling timeouts using Ruby, while JRuby appears unaffected by the change (doing some JVM magic).