### PR TITLE
Add previous response to Server#handle_error

### DIFF
--- a/lib/ione/rpc/server.rb
+++ b/lib/ione/rpc/server.rb
@@ -53,8 +53,8 @@ module Ione
       # Override this method to handle errors raised or returned by
       # {#handle_request} or any other part of the request handling (for example
       # the response encoding). In the event that {#handle_request} completed
-      # successfully, # the previous response will contain that result, otherwise
-      # it will be nil.
+      # successfully, the response will contain that result, otherwise it will
+      # be nil.
       #
       # When this method raises an error or returns a failed future there will be
       # no response for the request. Unless you use a custom client this means
@@ -68,11 +68,11 @@ module Ione
       # at the `debug` level.
       #
       # To remain backwards compatible, the method can be overridden to take only
-      # three arguments, in which case the previous response is omitted.
+      # three arguments, in which case the response is omitted.
       #
       # @return [Ione::Future<Object>] a future that will resolve to an alternate
       #   response for this request.
-      def handle_error(error, request, previous_response=nil, connection)
+      def handle_error(error, request, response=nil, connection)
         Ione::Future.failed(error)
       end
 
@@ -95,11 +95,11 @@ module Ione
       end
 
       # @private
-      def guarded_handle_error(error, request, previous_response, connection)
+      def guarded_handle_error(error, request, response, connection)
         if method(:handle_error).arity == 3
           handle_error(error, request, connection)
         else
-          handle_error(error, request, previous_response, connection)
+          handle_error(error, request, response, connection)
         end
       rescue => e
         Ione::Future.failed(e)


### PR DESCRIPTION
In order for the error handler to be able to distinguish between errors in Server#handle_request and others, this injects the resulting future value from Server#handle_request into Server#handle_error.

To retain backwards compatibility with Server#handle_error, the dispatch checks for a three-argument method and dispatches without the previous response in that case. In order to support calls to super from legacy servers, the new signature makes the previous response optional.

It is important to note that this doesn't capture actual sending errors, as that happens asynchronously from Ione's reactor thread. As far as I understand, there is not really any good way to capture this, and the connection will be closed if the actual writing fails, so the failure will be observable, but not really recoverable, as it would not be possible to connect to a particular message.